### PR TITLE
feat: allow sending without chat entry

### DIFF
--- a/main.py
+++ b/main.py
@@ -285,9 +285,13 @@ def gen_reply(msg: str) -> Optional[str]:
 
 
 def send_and_click(text: str):
-    x, y = CONFIG['CHAT_ENTRY']
-    tap(x, y)
-    time.sleep(1)
+    entry = CONFIG.get('CHAT_ENTRY')
+    if entry is None:
+        print("无需点击聊天入口")
+    else:
+        x, y = entry
+        tap(x, y)
+        time.sleep(1)
     send_text(text)
     time.sleep(0.5)
     sx, sy = CONFIG["SEND_BTN"]


### PR DESCRIPTION
## Summary
- handle None CHAT_ENTRY by skipping tap and notifying user

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b114563770833094ca0a9f6c4a7e31